### PR TITLE
Fix no set on empty list

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,13 +2,16 @@
 
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:82c9615a6e0101e567d46a222ac75494ccd22478cf614b57ca481cb646152f08"
   name = "github.com/hashicorp/hcl"
   packages = [
     "hcl/ast",
@@ -19,43 +22,75 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "UT"
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:c2c78ec087dc0a7b314f1df16c6afe2828f472d0c7b9109782e235fa1453905e"
+  name = "github.com/mattolenik/hclq"
+  packages = [
+    "cmd",
+    "query",
+  ]
+  pruneopts = "UT"
+  revision = "e84ade79842aaa89ed22b163d5d620cfaa3888cc"
+  version = "0.1.8"
+
+[[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:0e6b938fbfd0bdc2b909e64af1658ccf81666c9ddd728480e5f45e21f2952a48"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6644d46b81fa1831979c4cded0106e774e0ef0ab"
 
 [[projects]]
+  digest = "1:1b21a2b4058a779f290c7341cd93267492e0ecea6c8b54f64a4a5fd7ff131034"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:f85e109eda8f6080877185d1c39e98dd8795e1780c08beca28304b87fd855a1c"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5d4b869d6c27c3732cd2d3dfcaf4bad7cd22a16478687764fb691d26397e95f2"
+  input-imports = [
+    "github.com/hashicorp/hcl/hcl/ast",
+    "github.com/hashicorp/hcl/hcl/parser",
+    "github.com/hashicorp/hcl/hcl/printer",
+    "github.com/hashicorp/hcl/hcl/token",
+    "github.com/hashicorp/hcl/json/parser",
+    "github.com/mattolenik/hclq/cmd",
+    "github.com/mattolenik/hclq/query",
+    "github.com/spf13/cobra",
+    "github.com/stretchr/testify/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mattolenik/hclq/query"
+	"github.com/LudovicTOURMAN/hclq/query"
 	"github.com/spf13/cobra"
 )
 
@@ -26,8 +26,8 @@ var GetCmd = &cobra.Command{
 		raw := cmd.Flag("raw").Value.String() == "true"
 		resultPairs, isList, _, err := query.HCL(reader, qry)
 		results := []interface{}{}
-		for _, pair := range resultPairs {
-			results = append(results, pair.Value)
+		for _, pair := range resultPairs.Values {
+			results = append(results, pair)
 		}
 		// The return type can be a list if: the queried object IS a list, or if the query matched multiple single items
 		// So, return now if it's not a list and there is only one query result

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/LudovicTOURMAN/hclq/query"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/hcl/hcl/token"
 	jsonParser "github.com/hashicorp/hcl/json/parser"
-	"github.com/mattolenik/hclq/query"
 	"github.com/spf13/cobra"
 )
 
@@ -159,21 +159,17 @@ func setImpl(
 	}
 	resultPairs, isList, docRoot, err := query.HCL(reader, queryNodes)
 	if isList {
-		for _, pair := range resultPairs {
-			list, ok := pair.Node.(*ast.ListType)
-			if !ok {
-				return fmt.Errorf("Expected ListType as query result")
-			}
-			listAction(list)
+		list, ok := resultPairs.Node.(*ast.ListType)
+		if !ok {
+			return fmt.Errorf("Expected ListType as query result")
 		}
+		listAction(list)
 	} else {
-		for _, pair := range resultPairs {
-			item, ok := pair.Node.(*ast.LiteralType)
-			if !ok {
-				return fmt.Errorf("Expected LiteralType in query results")
-			}
-			valueAction(&item.Token)
+		item, ok := resultPairs.Node.(*ast.LiteralType)
+		if !ok {
+			return fmt.Errorf("Expected LiteralType in query results")
 		}
+		valueAction(&item.Token)
 	}
 
 	writer := os.Stdout


### PR DESCRIPTION
Using this terraform sample `bar.tf`:
```terraform
module "bar" {
  source = "../modules/foo"
  my_list = []
}
```
Running command `cat bar.tf | hclq set 'module.bar.my_list[]' '["foo","bar"]'` will result in not changing the value in the file/output.

This is caused by the fact that list is empty and we don't return a `Result` struct containing the concerned ast.Node